### PR TITLE
models/entities: fix test failure

### DIFF
--- a/models/entities/store_test.go
+++ b/models/entities/store_test.go
@@ -73,7 +73,7 @@ func TestStore(t *testing.T) {
 :"https://example.net/"
 ,"@type"
 :["https://w3c.org/ns/activitystreams#Article"]
-"https://www.w3.org/ns/activitystreams#content"
+,"https://www.w3.org/ns/activitystreams#content"
 :[{"@value":"my disrespectful teen son somehow got  hold of a gluten product and now he wants to become a cat girl"}]
 ,"https://www.w3.org/ns/activitystreams#name"
 :[{"@value":"Catgirls: how?"}]


### PR DESCRIPTION
apparently at some point our serialization was missing a comma and this ended
up accidentally encoded in the test