### PR TITLE
Cache $GOPATH/src in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ cache:
 
 # Do not cache our own sources, that would be silly.
 before_cache:
-- rm -rf $GOPATH/src/github.com/meowpub/meow
+- ( shopt -s dotglob && rm -rf $GOPATH/src/github.com/meowpub/meow/* )


### PR DESCRIPTION
This means we only check each dependency for updates and pull when necessary. Seems to cut ~1min off build times, although the gains are likely to improve as more dependencies are added.

Useful or pointless microoptimisation? You decide!