### PR TITLE
Smarter JSON-LD marshalling/unmarshalling

### DIFF
--- a/jsonld/langstring.go
+++ b/jsonld/langstring.go
@@ -27,11 +27,3 @@ func ToLangString(s string) LangString {
 func (s LangStringItem) String() string {
 	return s.Value
 }
-
-func (s LangStringItem) MarshalJSON() ([]byte, error) {
-	return s.Meta.Marshal(&s)
-}
-
-func (s *LangStringItem) UnmarshalJSON(data []byte) error {
-	return s.Meta.Unmarshal(data, s)
-}

--- a/jsonld/ref.go
+++ b/jsonld/ref.go
@@ -8,14 +8,6 @@ type RefItem struct {
 	Type Type `json:"@type,omitempty"`
 }
 
-func (ref *RefItem) MarshalJSON() ([]byte, error) {
-	return ref.Meta.Marshal(ref)
-}
-
-func (ref *RefItem) UnmarshalJSON(data []byte) error {
-	return ref.Meta.Unmarshal(data, ref)
-}
-
 func ToRef(id ID, typ Type) Ref {
 	return Ref{RefItem{ID: id, Type: typ}}
 }

--- a/jsonld/string.go
+++ b/jsonld/string.go
@@ -26,11 +26,3 @@ func ToString(s string) String {
 func (s StringItem) String() string {
 	return s.Value
 }
-
-func (s StringItem) MarshalJSON() ([]byte, error) {
-	return s.Meta.Marshal(&s)
-}
-
-func (s *StringItem) UnmarshalJSON(data []byte) error {
-	return s.Meta.Unmarshal(data, s)
-}

--- a/jsonld/transform_test.go
+++ b/jsonld/transform_test.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 
 	// "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const expanded = `
@@ -32,21 +33,33 @@ const compacted = `
 
 func TestCompact(t *testing.T) {
 	var compBuf bytes.Buffer
-	require.NoError(t, json.Compact(&compBuf, []byte(compacted)), "reference must compact")
+	require.NoError(t, json.Compact(&compBuf, []byte(compacted)), "reference must json compact")
+
+	var v map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(expanded), &v), "json.Unmarshal")
 
 	// We  can use a nil http.Client as no fetches should actually be done
-	res, err := Compact(nil, []byte(expanded), "https://example.com/something", "https://w3id.org/security/v1")
-
+	res, err := Compact(nil, v, "https://example.com/something", "https://w3id.org/security/v1")
 	require.NoError(t, err, "Compact should succeed")
-	require.Equal(t, compBuf.String(), string(res), "should produce expected result")
+
+	buf, err := json.Marshal(res)
+	require.NoError(t, err, "json.Marshal")
+
+	require.Equal(t, compBuf.String(), string(buf), "should produce expected result")
 }
 
 func TestExpand(t *testing.T) {
 	var expBuf bytes.Buffer
 	require.NoError(t, json.Compact(&expBuf, []byte(expanded)), "reference must compact")
 
-	res, err := Expand(nil, []byte(compacted), "https://example.com/something")
+	var v map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(compacted), &v), "json.Unmarshal")
 
+	res, err := Expand(nil, v, "https://example.com/something")
 	require.NoError(t, err, "Expand should succeed")
-	require.Equal(t, expBuf.String(), string(res), "should produce expected result")
+
+	buf, err := json.Marshal(res)
+	require.NoError(t, err, "json.Marshal")
+
+	require.Equal(t, expBuf.String(), string(buf), "should produce expected result")
 }

--- a/lib/context.go
+++ b/lib/context.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-redis/redis"
 	"github.com/jinzhu/gorm"
@@ -11,10 +12,11 @@ import (
 type ctxKey string
 
 const (
-	ctxKeyLogger ctxKey = "logger"
-	ctxKeyDB     ctxKey = "db"
-	ctxKeyRedis  ctxKey = "redis"
-	ctxKeyRender ctxKey = "render"
+	ctxKeyLogger     ctxKey = "logger"
+	ctxKeyDB         ctxKey = "db"
+	ctxKeyRedis      ctxKey = "redis"
+	ctxKeyRender     ctxKey = "render"
+	ctxKeyHttpClient ctxKey = "httpclient"
 )
 
 // GetLogger returns the logger associated with the context, or the global logger if none is set.
@@ -58,4 +60,15 @@ func GetRedis(ctx context.Context) *redis.Client {
 // WithRedis associates a Redis connection with a context.
 func WithRedis(ctx context.Context, r *redis.Client) context.Context {
 	return context.WithValue(ctx, ctxKeyRedis, r)
+}
+
+// GetHttpClient returns the Http client associated with the context, or nil
+func GetHttpClient(ctx context.Context) *http.Client {
+	r, _ := ctx.Value(ctxKeyHttpClient).(*http.Client)
+	return r
+}
+
+// WithHttpClient associates the HttpClient with a context
+func WithHttpClient(ctx context.Context, cli *http.Client) context.Context {
+	return context.WithValue(ctx, ctxKeyHttpClient, cli)
 }

--- a/models/entities/base.go
+++ b/models/entities/base.go
@@ -32,14 +32,6 @@ func (b Base) GetType() []string {
 	return b.Type
 }
 
-func (b *Base) UnmarshalJSON(data []byte) error {
-	return b.Meta.Unmarshal(data, b)
-}
-
-func (b *Base) MarshalJSON() ([]byte, error) {
-	return b.Marshal(b)
-}
-
 // api.Traversible
 func (b *Base) Traverse(ctx context.Context, pathElement string) (api.Handler, error) {
 	store := GetStore(ctx)

--- a/models/entities/entity.go
+++ b/models/entities/entity.go
@@ -39,10 +39,10 @@ type EntityKind struct {
 	Name string
 
 	// Unmarshall this object into an Entity
-	Unmarshall func([]byte) (Entity, error)
+	Unmarshall func(map[string]interface{}) (Entity, error)
 
 	// Marshall this object into an Entity
-	Marshall func(Entity) ([]byte, error)
+	Marshall func(Entity) (map[string]interface{}, error)
 }
 
 func RegisterKind(kind *EntityKind) {

--- a/models/entities/entity.go
+++ b/models/entities/entity.go
@@ -14,6 +14,7 @@ var (
 
 type Entity interface {
 	api.Traversible
+	api.Hydratable
 
 	// SetSnowflake sets the internal snowflake of the entity if unset
 	// This should only be called by Store

--- a/models/entities/object.go
+++ b/models/entities/object.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/meowpub/meow/jsonld"
+	"github.com/meowpub/meow/lib"
 	"github.com/meowpub/meow/server/api"
 )
 
@@ -39,6 +40,8 @@ type Object struct {
 	Inbox        jsonld.Ref        `json:"https://www.w3.org/ns/ldp#inbox,omitempty"`
 }
 
+var _ Entity = &Object{}
+
 var objectKind = &EntityKind{
 	Name: "object",
 	Unmarshall: func(obj map[string]interface{}) (Entity, error) {
@@ -61,11 +64,19 @@ func (*Object) GetKind() *EntityKind {
 
 // api.Handler
 
-// Return ourselves serialized as a json blob
-// TOOD: Compact!
+// Return ourselves
 func (o *Object) HandleRequest(ctx context.Context, req *http.Request) api.Response {
 	return api.Response{
 		Data: o,
+	}
+}
+
+// api.Hydratable
+func (self *Object) Hydrate(ctx context.Context) (interface{}, error) {
+	if o, err := jsonld.Marshal(self); err == nil {
+		return jsonld.Compact(lib.GetHttpClient(ctx), o.(map[string]interface{}), "", "https://www.w3.org/ns/activitystreams")
+	} else {
+		return nil, err
 	}
 }
 

--- a/models/entities/object.go
+++ b/models/entities/object.go
@@ -41,31 +41,22 @@ type Object struct {
 
 var objectKind = &EntityKind{
 	Name: "object",
-	Unmarshall: func(data []byte) (Entity, error) {
+	Unmarshall: func(obj map[string]interface{}) (Entity, error) {
 		v := &Object{}
-		if err := v.Meta.Unmarshal(data, v); err != nil {
+		return v, jsonld.Unmarshal(obj, v)
+	},
+	Marshall: func(e Entity) (map[string]interface{}, error) {
+		v, err := jsonld.Marshal(e.(*Object))
+		if err != nil {
 			return nil, err
 		} else {
-			return v, nil
+			return v.(map[string]interface{}), nil
 		}
-	},
-
-	// Marshall this object into an Entity
-	Marshall: func(e Entity) ([]byte, error) {
-		return e.(*Object).Meta.Marshal(e.(*Object))
 	},
 }
 
 func (*Object) GetKind() *EntityKind {
 	return objectKind
-}
-
-func (o *Object) UnmarshalJSON(data []byte) error {
-	return o.Meta.Unmarshal(data, o)
-}
-
-func (o *Object) MarshalJSON() ([]byte, error) {
-	return o.Marshal(o)
 }
 
 // api.Handler

--- a/models/entities/person.go
+++ b/models/entities/person.go
@@ -22,18 +22,17 @@ type Person struct {
 
 var personKind = &EntityKind{
 	Name: "person",
-	Unmarshall: func(data []byte) (Entity, error) {
-		v := &Person{}
-		if err := v.Meta.Unmarshal(data, v); err != nil {
+	Unmarshall: func(obj map[string]interface{}) (Entity, error) {
+		v := &Object{}
+		return v, jsonld.Unmarshal(obj, v)
+	},
+	Marshall: func(e Entity) (map[string]interface{}, error) {
+		v, err := jsonld.Marshal(e.(*Object))
+		if err != nil {
 			return nil, err
 		} else {
-			return v, nil
+			return v.(map[string]interface{}), nil
 		}
-	},
-
-	// Marshall this object into an Entity
-	Marshall: func(e Entity) ([]byte, error) {
-		return e.(*Person).Meta.Marshal(e.(*Person))
 	},
 }
 
@@ -43,14 +42,6 @@ func (*Person) GetKind() *EntityKind {
 
 func (p *Person) GetUser(store models.UserStore) (*models.User, error) {
 	return store.GetBySnowflake(p.GetSnowflake())
-}
-
-func (o *Person) UnmarshalJSON(data []byte) error {
-	return o.Meta.Unmarshal(data, o)
-}
-
-func (o *Person) MarshalJSON() ([]byte, error) {
-	return o.Marshal(o)
 }
 
 // Return ourselves serialized as a json blob

--- a/models/entities/store_test.go
+++ b/models/entities/store_test.go
@@ -68,18 +68,7 @@ func TestStore(t *testing.T) {
 		raw.EXPECT().Save(gomock.Eq(models.Entity{
 			ID:   353894652568535040,
 			Kind: "object",
-			Data: models.JSONB(`
-{"@id"
-:"https://example.net/"
-,"@type"
-:["https://w3c.org/ns/activitystreams#Article"]
-,"https://www.w3.org/ns/activitystreams#content"
-:[{"@value":"my disrespectful teen son somehow got  hold of a gluten product and now he wants to become a cat girl"}]
-,"https://www.w3.org/ns/activitystreams#name"
-:[{"@value":"Catgirls: how?"}]
-,"https://www.w3.org/ns/activitystreams#url"
-:[{"@id":"http://catgirl.how/"}]
-}`[1:]),
+			Data: models.JSONB(`{"@id":"https://example.net/","@type":["https://w3c.org/ns/activitystreams#Article"],"https://www.w3.org/ns/activitystreams#content":[{"@value":"my disrespectful teen son somehow got  hold of a gluten product and now he wants to become a cat girl"}],"https://www.w3.org/ns/activitystreams#name":[{"@value":"Catgirls: how?"}],"https://www.w3.org/ns/activitystreams#url":[{"@id":"http://catgirl.how/"}]}`),
 		})).Return(nil)
 		err = store.Save(glutenObj)
 		require.NoError(t, err, "Saving modified entity")

--- a/server/api/response.go
+++ b/server/api/response.go
@@ -2,12 +2,20 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 
 	"github.com/pkg/errors"
 )
 
 var _ http.ResponseWriter = &Response{}
+
+// Hydratable indicates that this object can be "hydrated"
+// before rendering
+type Hydratable interface {
+	// Hydrates the object
+	Hydrate(context.Context) (interface{}, error)
+}
 
 // Response is a structured response. Implements http.ResponseWriter.
 type Response struct {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -130,20 +130,31 @@ func (r *Router) Render(rw http.ResponseWriter, req *http.Request, resp Response
 
 	// TODO: Do proper content negotiation here.
 	var err error
-	switch {
-	case resp.Template != "":
-		err = r.rend.HTML(rw, resp.Status, resp.Template, resp.Data)
-	case resp.Data != nil:
-		switch data := resp.Data.(type) {
-		case string:
-			err = r.rend.Text(rw, resp.Status, data)
-		case []byte:
-			err = r.rend.Data(rw, resp.Status, data)
+
+	data := resp.Data
+	if h, ok := data.(Hydratable); ok {
+		L.Info("Hydrating")
+		data, err = h.Hydrate(req.Context())
+	} else {
+		L.Info("Can't hydrate")
+	}
+
+	if err == nil {
+		switch {
+		case resp.Template != "":
+			err = r.rend.HTML(rw, resp.Status, resp.Template, resp.Data)
+		case data != nil:
+			switch data := data.(type) {
+			case string:
+				err = r.rend.Text(rw, resp.Status, data)
+			case []byte:
+				err = r.rend.Data(rw, resp.Status, data)
+			default:
+				err = r.rend.JSON(rw, resp.Status, data)
+			}
 		default:
-			err = r.rend.JSON(rw, resp.Status, data)
+			rw.WriteHeader(resp.Status)
 		}
-	default:
-		rw.WriteHeader(resp.Status)
 	}
 	if err != nil {
 		L.Error("Failed to render response", zap.Error(err))


### PR DESCRIPTION
Firstly, we change our JSON-LD marshalling/unmarshalling library
convert to map[string]interface{}s. This means we dont' have to
roundtrip between structs <-> string <-> map[string]interface{}
for compaction/expansion

Secondly, we introduce "hydration" into the router. This lets
resources render themselves

Finally, we combine these two and teach entites how to hydrate 
themselves. They are now output as compacted JSON-LD