### PR TITLE
Formalised LogIn()/LogOut(), handle invalid sessions

### DIFF
--- a/server/oauth/authentication.go
+++ b/server/oauth/authentication.go
@@ -14,6 +14,9 @@ import (
 )
 
 const BearerPrefix = "Bearer "
+
+const AccessTokenSessionKey = "access_token"
+
 const accessTokenKey ctxKey = "AccessToken"
 
 // Authenticated retrieves the user credentials for the request (if any)
@@ -50,12 +53,8 @@ func WithToken(ctx context.Context, tok *models.AccessToken) context.Context {
 }
 
 func GetToken(ctx context.Context) *models.AccessToken {
-	tok := ctx.Value(accessTokenKey)
-	if tok != nil {
-		return tok.(*models.AccessToken)
-	} else {
-		return nil
-	}
+	tok, _ := ctx.Value(accessTokenKey).(*models.AccessToken)
+	return tok
 }
 
 func AuthenticationMiddleware(next api.Handler) api.Handler {

--- a/server/oauth/session.go
+++ b/server/oauth/session.go
@@ -1,0 +1,49 @@
+package oauth
+
+import (
+	"context"
+
+	"github.com/meowpub/meow/lib"
+	"github.com/meowpub/meow/models"
+	"github.com/meowpub/meow/server/middleware"
+)
+
+// Sets an access token in the session for the specified user.
+func LogIn(ctx context.Context, user *models.User) error {
+	stores := models.GetStores(ctx)
+
+	// Generate and store an access token.
+	token, err := lib.GenToken()
+	if err != nil {
+		return err
+	}
+	tok := &models.AccessToken{
+		Token:    token,
+		ClientID: WebClient.GetId(),
+		Scope:    "web",
+		AuthorizationUserData: models.AuthorizationUserData{
+			UserID: user.ID,
+		},
+	}
+	if err := stores.AccessTokens().Set(tok, WebAccessTokenTTL); err != nil {
+		return err
+	}
+
+	// Stick it in the session.
+	middleware.GetSession(ctx).Values[AccessTokenSessionKey] = tok.Token
+
+	return nil
+}
+
+// Clears and invalidates the access token in the session, if any.
+func LogOut(ctx context.Context) error {
+	stores := models.GetStores(ctx)
+	sess := middleware.GetSession(ctx)
+
+	// Retrieve the access token from the session, then drop it.
+	tok, _ := sess.Values[AccessTokenSessionKey].(string)
+	delete(sess.Values, AccessTokenSessionKey)
+
+	// Invalidate it.
+	return stores.AccessTokens().Delete(tok)
+}


### PR DESCRIPTION
Previously, deleting a user and then accessing the site (or otherwise using an invalid session) would get some really strange results, including the login page 404ing as it attempts to look up a nonexistent access token.

This just clears the session if it's invalid and you're attempting to access the login page specifically, under the assumption that attempting to access anything else that requires a session will redirect to the login page.