### PR TITLE
Use custom Request type instead of *http.Request

### DIFF
--- a/lib/url.go
+++ b/lib/url.go
@@ -17,3 +17,11 @@ func NormalizeURL(u url.URL) url.URL {
 
 	return u
 }
+
+func RootURL(url url.URL) url.URL {
+	// Build the Url of the root object for traversal
+	rootURL := url
+	rootURL.Path = ""
+	rootURL.RawPath = rootURL.EscapedPath()
+	return rootURL
+}

--- a/models/entities/activity.go
+++ b/models/entities/activity.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/meowpub/meow/jsonld"
@@ -60,8 +59,8 @@ func (*Activity) GetKind() *EntityKind {
 // api.Handler
 
 // Return ourselves
-func (o *Activity) HandleRequest(ctx context.Context, req *http.Request) api.Response {
-	return handleEntityGetRequest(ctx, o, req)
+func (o *Activity) HandleRequest(req api.Request) api.Response {
+	return handleEntityGetRequest(req, o)
 }
 
 func (self *Activity) Hydrate(ctx context.Context, stack []snowflake.ID) (interface{}, error) {

--- a/models/entities/object.go
+++ b/models/entities/object.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/meowpub/meow/jsonld"
@@ -80,8 +79,8 @@ func (*Object) GetKind() *EntityKind {
 // api.Handler
 
 // Return ourselves
-func (o *Object) HandleRequest(ctx context.Context, req *http.Request) api.Response {
-	return handleEntityGetRequest(ctx, o, req)
+func (o *Object) HandleRequest(req api.Request) api.Response {
+	return handleEntityGetRequest(req, o)
 }
 
 func (self *Object) Hydrate(ctx context.Context, stack []snowflake.ID) (interface{}, error) {

--- a/models/entities/person.go
+++ b/models/entities/person.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/meowpub/meow/jsonld"
@@ -116,8 +115,8 @@ func (p *Person) GetUser(store models.UserStore) (*models.User, error) {
 }
 
 // Return ourselves
-func (o *Person) HandleRequest(ctx context.Context, req *http.Request) api.Response {
-	return handleEntityGetRequest(ctx, o, req)
+func (o *Person) HandleRequest(req api.Request) api.Response {
+	return handleEntityGetRequest(req, o)
 }
 
 func (self *Person) GetOutbox(ctx context.Context) (*Stream, error) {

--- a/models/entities/stream.go
+++ b/models/entities/stream.go
@@ -2,7 +2,6 @@ package entities
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/meowpub/meow/jsonld"
@@ -101,8 +100,8 @@ func (self *Stream) InsertItem(ctx context.Context, ent Entity) error {
 }
 
 // Return ourselves
-func (o *Stream) HandleRequest(ctx context.Context, req *http.Request) api.Response {
-	return handleEntityGetRequest(ctx, o, req)
+func (o *Stream) HandleRequest(req api.Request) api.Response {
+	return handleEntityGetRequest(req, o)
 }
 
 func init() {

--- a/models/entities/util.go
+++ b/models/entities/util.go
@@ -17,7 +17,7 @@ func compact(ctx context.Context, data interface{}) (interface{}, error) {
 	return jsonld.Compact(lib.GetHttpClient(ctx), data.(map[string]interface{}), "", "https://www.w3.org/ns/activitystreams")
 }
 
-func handleEntityGetRequest(ctx context.Context, e Entity, req *http.Request) api.Response {
+func handleEntityGetRequest(req api.Request, e Entity) api.Response {
 	if req.Method != http.MethodGet && req.Method != http.MethodOptions && req.Method != http.MethodHead {
 		return api.Response{
 			Status: http.StatusMethodNotAllowed,
@@ -25,12 +25,12 @@ func handleEntityGetRequest(ctx context.Context, e Entity, req *http.Request) ap
 		}
 	}
 
-	d, err := e.Hydrate(ctx, []snowflake.ID{})
+	d, err := e.Hydrate(req, []snowflake.ID{})
 	if err != nil {
 		return api.ErrorResponse(err)
 	}
 
-	o, err := compact(ctx, d)
+	o, err := compact(req, d)
 	if err != nil {
 		return api.ErrorResponse(err)
 	}

--- a/server/api/forms.go
+++ b/server/api/forms.go
@@ -8,13 +8,13 @@ import (
 
 var formDecoder = form.NewDecoder()
 
-func DecodeForm(req *http.Request, v interface{}) error {
+func DecodeForm(req Request, v interface{}) error {
 	if err := req.ParseForm(); err != nil {
 		return Wrap(err, http.StatusBadRequest)
 	}
 	return Wrap(formDecoder.Decode(v, req.Form), http.StatusBadRequest)
 }
 
-func DecodeQuery(req *http.Request, v interface{}) error {
+func DecodeQuery(req Request, v interface{}) error {
 	return Wrap(formDecoder.Decode(v, req.URL.Query()), http.StatusBadRequest)
 }

--- a/server/api/handler.go
+++ b/server/api/handler.go
@@ -1,20 +1,15 @@
 package api
 
-import (
-	"context"
-	"net/http"
-)
-
 // Handler is a more convenient structure for an HTTP handler. By returning responses instead of
 // using the ResponseWriter, we prevent errors arising from forgetting to return after a render
 // call, and let content negotiation occur outside of the handlers themselves.
 type Handler interface {
-	HandleRequest(ctx context.Context, req *http.Request) Response
+	HandleRequest(req Request) Response
 }
 
 // HandlerFunc lets a function act as a Handler.
-type HandlerFunc func(ctx context.Context, req *http.Request) Response
+type HandlerFunc func(Request) Response
 
-func (h HandlerFunc) HandleRequest(ctx context.Context, req *http.Request) Response {
-	return h(ctx, req)
+func (h HandlerFunc) HandleRequest(req Request) Response {
+	return h(req)
 }

--- a/server/api/middleware_test.go
+++ b/server/api/middleware_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,43 +9,42 @@ import (
 )
 
 func TestChain(t *testing.T) {
-	h := HandlerFunc(func(ctx context.Context, req *http.Request) Response {
+	h := HandlerFunc(func(req Request) Response {
 		return Response{Data: "hi"}
 	})
 
-	req := httptest.NewRequest("GET", "/path", nil)
-	ctx := req.Context()
+	req := Request{httptest.NewRequest("GET", "/path", nil)}
 
 	t.Run("No Middleware", func(t *testing.T) {
-		assert.Equal(t, Response{Data: "hi"}, Chain(h).HandleRequest(ctx, req))
+		assert.Equal(t, Response{Data: "hi"}, Chain(h).HandleRequest(req))
 	})
 
 	t.Run("One Middleware", func(t *testing.T) {
 		mw := func(next Handler) Handler {
-			return HandlerFunc(func(ctx context.Context, req *http.Request) Response {
-				rsp := next.HandleRequest(ctx, req)
+			return HandlerFunc(func(req Request) Response {
+				rsp := next.HandleRequest(req)
 				rsp.Status = http.StatusNotFound
 				return rsp
 			})
 		}
-		assert.Equal(t, Response{Data: "hi", Status: 404}, Chain(h, mw).HandleRequest(ctx, req))
+		assert.Equal(t, Response{Data: "hi", Status: 404}, Chain(h, mw).HandleRequest(req))
 	})
 
 	t.Run("Two Middleware", func(t *testing.T) {
 		mw1 := func(next Handler) Handler {
-			return HandlerFunc(func(ctx context.Context, req *http.Request) Response {
-				rsp := next.HandleRequest(ctx, req)
+			return HandlerFunc(func(req Request) Response {
+				rsp := next.HandleRequest(req)
 				rsp.Status = http.StatusNotFound
 				return rsp
 			})
 		}
 		mw2 := func(next Handler) Handler {
-			return HandlerFunc(func(ctx context.Context, req *http.Request) Response {
-				rsp := next.HandleRequest(ctx, req)
+			return HandlerFunc(func(req Request) Response {
+				rsp := next.HandleRequest(req)
 				rsp.Data = "bye"
 				return rsp
 			})
 		}
-		assert.Equal(t, Response{Data: "bye", Status: 404}, Chain(h, mw1, mw2).HandleRequest(ctx, req))
+		assert.Equal(t, Response{Data: "bye", Status: 404}, Chain(h, mw1, mw2).HandleRequest(req))
 	})
 }

--- a/server/api/node.go
+++ b/server/api/node.go
@@ -13,9 +13,9 @@ type Node struct {
 	Children map[string]Handler
 }
 
-func (n Node) HandleRequest(ctx context.Context, req *http.Request) Response {
+func (n Node) HandleRequest(req Request) Response {
 	if n.Self != nil {
-		return n.Self.HandleRequest(ctx, req)
+		return n.Self.HandleRequest(req)
 	}
 	return Response{Status: http.StatusNotFound}
 }

--- a/server/api/node_test.go
+++ b/server/api/node_test.go
@@ -13,18 +13,18 @@ import (
 func TestNode(t *testing.T) {
 	leaf := &Node{
 		Self: &Node{
-			Self: HandlerFunc(func(ctx context.Context, req *http.Request) Response {
+			Self: HandlerFunc(func(req Request) Response {
 				return Response{Data: "leaf"}
 			}),
 			Children: map[string]Handler{
-				"self-leaf": HandlerFunc(func(ctx context.Context, req *http.Request) Response {
+				"self-leaf": HandlerFunc(func(req Request) Response {
 					return Response{Data: "self-leaf"}
 				}),
 			},
 		},
 	}
 	root := &Node{
-		Self: HandlerFunc(func(ctx context.Context, req *http.Request) Response {
+		Self: HandlerFunc(func(req Request) Response {
 			return Response{Data: "OK"}
 		}),
 		Children: map[string]Handler{
@@ -33,8 +33,8 @@ func TestNode(t *testing.T) {
 	}
 
 	t.Run("HandleRequest", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "https://example.com/", nil)
-		assert.Equal(t, Response{Data: "OK"}, root.HandleRequest(req.Context(), req))
+		req := Request{httptest.NewRequest("GET", "https://example.com/", nil)}
+		assert.Equal(t, Response{Data: "OK"}, root.HandleRequest(req))
 	})
 
 	t.Run("Traverse", func(t *testing.T) {
@@ -49,21 +49,21 @@ func TestNode(t *testing.T) {
 			assert.Equal(t, leaf, h)
 
 			t.Run("HandleRequest", func(t *testing.T) {
-				req := httptest.NewRequest("GET", "https://example.com/leaf", nil)
-				assert.Equal(t, Response{Data: "leaf"}, h.HandleRequest(req.Context(), req))
+				req := Request{httptest.NewRequest("GET", "https://example.com/leaf", nil)}
+				assert.Equal(t, Response{Data: "leaf"}, h.HandleRequest(req))
 			})
 
 			t.Run("Self Traverse", func(t *testing.T) {
 				h2, err := h.(*Node).Traverse(context.Background(), "self-leaf")
 				require.NoError(t, err)
-				req := httptest.NewRequest("GET", "https://example.com/leaf/self-leaf", nil)
-				assert.Equal(t, Response{Data: "self-leaf"}, h2.HandleRequest(req.Context(), req))
+				req := Request{httptest.NewRequest("GET", "https://example.com/leaf/self-leaf", nil)}
+				assert.Equal(t, Response{Data: "self-leaf"}, h2.HandleRequest(req))
 			})
 		})
 	})
 }
 
 func TestNodeNoSelf(t *testing.T) {
-	req := httptest.NewRequest("GET", "https://example.com/", nil)
-	assert.Equal(t, Response{Status: http.StatusNotFound}, (&Node{}).HandleRequest(req.Context(), req))
+	req := Request{httptest.NewRequest("GET", "https://example.com/", nil)}
+	assert.Equal(t, Response{Status: http.StatusNotFound}, (&Node{}).HandleRequest(req))
 }

--- a/server/api/request.go
+++ b/server/api/request.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/meowpub/meow/lib"
+)
+
+type Request struct{ *http.Request }
+
+var _ context.Context = &Request{}
+
+func (r Request) Deadline() (deadline time.Time, ok bool) {
+	return r.Context().Deadline()
+}
+
+func (r Request) Done() <-chan struct{} {
+	return r.Context().Done()
+}
+
+func (r Request) Err() error {
+	return r.Context().Err()
+}
+
+func (r Request) Value(key interface{}) interface{} {
+	return r.Context().Value(key)
+}
+
+func (r Request) WithContext(ctx context.Context) Request {
+	return Request{r.Request.WithContext(unwrapContext(ctx))}
+}
+
+func (r Request) Context() context.Context {
+	return unwrapContext(r.Request.Context())
+}
+
+func unwrapContext(ctx context.Context) context.Context {
+	for {
+		switch r := ctx.(type) {
+		case Request:
+			ctx = r.Request.Context()
+
+		case *Request:
+			ctx = r.Request.Context()
+
+		default:
+			return ctx
+		}
+	}
+}
+
+func (req Request) ResourceURL() url.URL {
+	host, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		host = req.Host
+	}
+
+	// Normalize the url
+	url := *req.URL
+	url.Scheme = "https"
+	url.Host = host
+	url = lib.NormalizeURL(url)
+
+	return url
+}
+
+func (req Request) RootURL() url.URL {
+	return lib.RootURL(req.ResourceURL())
+}

--- a/server/middleware/sessions.go
+++ b/server/middleware/sessions.go
@@ -22,15 +22,14 @@ func GetSession(ctx context.Context) *sessions.Session {
 
 func AddSession(store sessions.Store) func(next api.Handler) api.Handler {
 	return func(next api.Handler) api.Handler {
-		return api.HandlerFunc(func(ctx context.Context, req *http.Request) api.Response {
-			sess, err := store.Get(req, "session")
+		return api.HandlerFunc(func(req api.Request) api.Response {
+			sess, err := store.Get(req.Request, "session")
 			if err != nil {
 				return api.Response{Error: api.Wrap(err, http.StatusBadRequest)}
 			}
-			ctx = WithSession(ctx, sess)
-			req = req.WithContext(ctx)
-			resp := next.HandleRequest(ctx, req)
-			if err := sess.Save(req, &resp); err != nil {
+			req = req.WithContext(WithSession(req.Context(), sess))
+			resp := next.HandleRequest(req)
+			if err := sess.Save(req.Request, &resp); err != nil {
 				return api.Response{Error: api.Wrap(err, http.StatusBadRequest)}
 			}
 			return resp

--- a/server/util.go
+++ b/server/util.go
@@ -1,14 +1,13 @@
 package server
 
 import (
-	"net/http"
 	"net/url"
 
 	"github.com/pkg/errors"
 )
 
 // Safety checks a redirect URI to prevent open redirection vulnerabilities.
-func SanitizeRedirectURI(rawuri string, req *http.Request) (string, error) {
+func SanitizeRedirectURI(rawuri string) (string, error) {
 	if rawuri == "" {
 		return "", nil
 	}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,19 +9,16 @@ import (
 
 func TestSanitiseRedirectURIs(t *testing.T) {
 	t.Run("Relative", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "https://example.com/page", nil)
-		u, err := SanitizeRedirectURI("/some/page", req)
+		u, err := SanitizeRedirectURI("/some/page")
 		require.NoError(t, err)
 		assert.Equal(t, "/some/page", u)
 	})
 	t.Run("Absolute", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "https://example.com/page", nil)
-		_, err := SanitizeRedirectURI("https://example.com/some/page", req)
+		_, err := SanitizeRedirectURI("https://example.com/some/page")
 		require.EqualError(t, err, "absolute urls not allowed in redirect uris: https://example.com/some/page")
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "https://example.com/page", nil)
-		_, err := SanitizeRedirectURI("://", req)
+		_, err := SanitizeRedirectURI("://")
 		require.EqualError(t, err, "parse ://: missing protocol scheme")
 	})
 }


### PR DESCRIPTION
http.Request carries around a context, but does so in a way which
is rather annoying to use. We wrap it to add

 * An implementation of context.Context which delegates to that
   context, so you can just use a request as a context
 * Accessors for getting Root and Resource URLs

Adjust all handler functions to not take a separate context