### PR TITLE
misc ld.Object fixes

### DIFF
--- a/ld/cast.go
+++ b/ld/cast.go
@@ -42,21 +42,32 @@ func ToArray(raw interface{}) []interface{} {
 		return nil
 	case []interface{}:
 		return v
+	case []string:
+		vs := make([]interface{}, len(v))
+		for i, vv := range v {
+			vs[i] = vv
+		}
+		return vs
 	default:
 		return []interface{}{raw}
 	}
 }
 
 func ToStringArray(raw interface{}) []string {
-	arr := ToArray(raw)
-	if arr == nil {
-		return nil
+	switch v := raw.(type) {
+	case []string:
+		return v
+	default:
+		arr := ToArray(raw)
+		if arr == nil {
+			return nil
+		}
+		strs := make([]string, len(arr))
+		for i, v := range arr {
+			strs[i] = ToString(v)
+		}
+		return strs
 	}
-	strs := make([]string, len(arr))
-	for i, v := range arr {
-		strs[i] = ToString(v)
-	}
-	return strs
 }
 
 func ToObject(raw interface{}) *Object {

--- a/ld/cast.go
+++ b/ld/cast.go
@@ -33,10 +33,10 @@ func ToString(raw interface{}) string {
 	}
 }
 
-// Casts to an array.
-// If the value is an array, it's returned verbatim.
-// If not, it's returned wrapped in an array with one item.
-func ToArray(raw interface{}) []interface{} {
+// Casts to a slice.
+// If the value is a slice, it's returned verbatim.
+// If not, it's returned wrapped in a slice with one item.
+func ToSlice(raw interface{}) []interface{} {
 	switch v := raw.(type) {
 	case nil:
 		return nil
@@ -53,12 +53,12 @@ func ToArray(raw interface{}) []interface{} {
 	}
 }
 
-func ToStringArray(raw interface{}) []string {
+func ToStringSlice(raw interface{}) []string {
 	switch v := raw.(type) {
 	case []string:
 		return v
 	default:
-		arr := ToArray(raw)
+		arr := ToSlice(raw)
 		if arr == nil {
 			return nil
 		}

--- a/ld/ns/index_test.go
+++ b/ld/ns/index_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestManifest(t *testing.T) {
 	t.Run("Unknown Type", func(t *testing.T) {
-		o, err := ld.NewObject([]byte(`{
+		o, err := ld.ParseObject([]byte(`{
 			"@id": "https://example.com/@jsmith",
 			"@type": ["http://schema.org/Person"],
 			"http://schema.org/name": [{"@value": "John Smith"}]
@@ -21,7 +21,7 @@ func TestManifest(t *testing.T) {
 		assert.Empty(t, Manifest(o))
 	})
 	t.Run("One Type", func(t *testing.T) {
-		o, err := ld.NewObject([]byte(`{
+		o, err := ld.ParseObject([]byte(`{
 			"@id": "https://example.com/@jsmith",
 			"@type": ["http://www.w3.org/ns/activitystreams#Person"],
 			"http://www.w3.org/ns/activitystreams#name": [{"@value": "John Smith"}]
@@ -34,7 +34,7 @@ func TestManifest(t *testing.T) {
 	})
 	t.Run("Two Types", func(t *testing.T) {
 		// A person who is also a place... how mysterious.
-		o, err := ld.NewObject([]byte(`{
+		o, err := ld.ParseObject([]byte(`{
 			"@id": "https://example.com/@jsmith",
 			"@type": [
 				"http://www.w3.org/ns/activitystreams#Person",

--- a/ld/object.go
+++ b/ld/object.go
@@ -16,6 +16,13 @@ type Object struct {
 	typ   []string
 }
 
+func NewObject(id string, types ...string) *Object {
+	obj := &Object{}
+	obj.SetID(id)
+	obj.SetType(types...)
+	return obj
+}
+
 // Creates a new object from a JSON object.
 func ParseObject(data []byte) (*Object, error) {
 	var obj Object

--- a/ld/object.go
+++ b/ld/object.go
@@ -17,13 +17,13 @@ type Object struct {
 }
 
 // Creates a new object from a JSON object.
-func NewObject(data []byte) (*Object, error) {
+func ParseObject(data []byte) (*Object, error) {
 	var obj Object
 	return &obj, json.Unmarshal(data, &obj.V)
 }
 
 // Creates a new list of objects from a JSON array.
-func NewObjects(data []byte) ([]*Object, error) {
+func ParseObjects(data []byte) ([]*Object, error) {
 	var vs []map[string]interface{}
 	if err := json.Unmarshal(data, &vs); err != nil {
 		return nil, err

--- a/ld/object.go
+++ b/ld/object.go
@@ -64,6 +64,11 @@ func (obj *Object) ID() string {
 	return obj.id
 }
 
+// Sets the object's @id.
+func (obj *Object) SetID(id string) {
+	obj.Set("@id", id)
+}
+
 // Returns the object's @value, or "".
 func (obj *Object) Value() string {
 	if obj == nil {
@@ -73,6 +78,11 @@ func (obj *Object) Value() string {
 		obj.value = ToString(obj.Get("@value"))
 	}
 	return obj.value
+}
+
+// Sets the object's @value.
+func (obj *Object) SetValue(v string) {
+	obj.Set("@value", v)
 }
 
 // Returns the object's @type, or nil.
@@ -86,6 +96,11 @@ func (obj *Object) Type() []string {
 	return obj.typ
 }
 
+// Sets the object's @type.
+func (obj *Object) SetType(ts ...string) {
+	obj.Set("@type", ts)
+}
+
 // Nil-safe getter for attributes.
 func (obj *Object) Get(key string) interface{} {
 	if obj != nil && obj.V != nil {
@@ -96,8 +111,21 @@ func (obj *Object) Get(key string) interface{} {
 
 // Nil-safe setter for attributes.
 func (obj *Object) Set(key string, value interface{}) {
-	if obj != nil {
-		obj.V[key] = value
+	if obj == nil {
+		return
+	}
+	if obj.V == nil {
+		obj.V = map[string]interface{}{key: value}
+		return
+	}
+	obj.V[key] = value
+	switch key {
+	case "@id":
+		obj.id = ""
+	case "@value":
+		obj.value = ""
+	case "@type":
+		obj.typ = nil
 	}
 }
 

--- a/ld/object.go
+++ b/ld/object.go
@@ -81,7 +81,7 @@ func (obj *Object) Type() []string {
 		return nil
 	}
 	if obj.typ == nil {
-		obj.typ = ToStringArray(obj.Get("@type"))
+		obj.typ = ToStringSlice(obj.Get("@type"))
 	}
 	return obj.typ
 }
@@ -109,9 +109,9 @@ func (obj *Object) Apply(patch Entity, mergeArrays bool) error {
 		if k == "@id" || !mergeArrays {
 			obj.V[k] = v
 		} else if arr, ok := v.([]interface{}); ok {
-			obj.V[k] = append(ToArray(obj.Get(k)), arr...)
+			obj.V[k] = append(ToSlice(obj.Get(k)), arr...)
 		} else {
-			obj.V[k] = append(ToArray(obj.Get(k)), v)
+			obj.V[k] = append(ToSlice(obj.Get(k)), v)
 		}
 	}
 	return nil

--- a/ld/object_test.go
+++ b/ld/object_test.go
@@ -47,6 +47,13 @@ func TestObjectID(t *testing.T) {
 	})
 }
 
+func TestObjectSetID(t *testing.T) {
+	obj := NewObject("https://example.com")
+	assert.Equal(t, "https://example.com", obj.ID())
+	obj.SetID("https://example.com/boop")
+	assert.Equal(t, "https://example.com/boop", obj.ID())
+}
+
 func TestObjectType(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
 		obj, err := ParseObject([]byte(`{}`))
@@ -93,6 +100,13 @@ func TestObjectType(t *testing.T) {
 			"http://www.w3.org/ns/activitystreams#Image",
 		}, obj.Type())
 	})
+}
+
+func TestObjectSetType(t *testing.T) {
+	obj := NewObject("https://example.com", "http://www.w3.org/ns/activitystreams#Note")
+	assert.Equal(t, []string{"http://www.w3.org/ns/activitystreams#Note"}, obj.Type())
+	obj.SetType("http://www.w3.org/ns/activitystreams#Image")
+	assert.Equal(t, []string{"http://www.w3.org/ns/activitystreams#Image"}, obj.Type())
 }
 
 func TestObjectMerge(t *testing.T) {

--- a/ld/object_test.go
+++ b/ld/object_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestObjectID(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{}`))
+		obj, err := ParseObject([]byte(`{}`))
 		require.NoError(t, err)
 		assert.Equal(t, "", obj.ID())
 	})
 
 	t.Run("Null", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": null
 		}`))
 		require.NoError(t, err)
@@ -23,7 +23,7 @@ func TestObjectID(t *testing.T) {
 	})
 
 	t.Run("Number", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": 12345
 		}`))
 		require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestObjectID(t *testing.T) {
 	})
 
 	t.Run("String", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": "https://example.com"
 		}`))
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestObjectID(t *testing.T) {
 	})
 
 	t.Run("Array", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": ["https://example.com/1", "https://example.com/2"]
 		}`))
 		require.NoError(t, err)
@@ -49,19 +49,19 @@ func TestObjectID(t *testing.T) {
 
 func TestObjectType(t *testing.T) {
 	t.Run("None", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{}`))
+		obj, err := ParseObject([]byte(`{}`))
 		require.NoError(t, err)
 		assert.Empty(t, obj.Type())
 	})
 
 	t.Run("Null", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{"@type": null}`))
+		obj, err := ParseObject([]byte(`{"@type": null}`))
 		require.NoError(t, err)
 		assert.Empty(t, obj.Type())
 	})
 
 	t.Run("Number", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@type": 12345
 		}`))
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestObjectType(t *testing.T) {
 	})
 
 	t.Run("String", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@type": "http://www.w3.org/ns/activitystreams#Note"
 		}`))
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestObjectType(t *testing.T) {
 	})
 
 	t.Run("Array", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@type": [
 				"http://www.w3.org/ns/activitystreams#Note",
 				"http://www.w3.org/ns/activitystreams#Image"
@@ -97,11 +97,11 @@ func TestObjectType(t *testing.T) {
 
 func TestObjectMerge(t *testing.T) {
 	t.Run("New", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": "https://example.com"
 		}`))
 		require.NoError(t, err)
-		patch, err := NewObject([]byte(`{
+		patch, err := ParseObject([]byte(`{
 			"@id": "https://example.com",
 			"http://www.w3.org/ns/activitystreams#content": "hi"
 		}`))
@@ -114,12 +114,12 @@ func TestObjectMerge(t *testing.T) {
 	})
 
 	t.Run("Replace", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": "https://example.com",
 			"http://www.w3.org/ns/activitystreams#content": "hi"
 		}`))
 		require.NoError(t, err)
-		patch, err := NewObject([]byte(`{
+		patch, err := ParseObject([]byte(`{
 			"@id": "https://example.com",
 			"http://www.w3.org/ns/activitystreams#content": "bye"
 		}`))
@@ -132,12 +132,12 @@ func TestObjectMerge(t *testing.T) {
 	})
 
 	t.Run("Merge", func(t *testing.T) {
-		obj, err := NewObject([]byte(`{
+		obj, err := ParseObject([]byte(`{
 			"@id": "https://example.com",
 			"http://www.w3.org/ns/activitystreams#content": "hi"
 		}`))
 		require.NoError(t, err)
-		patch, err := NewObject([]byte(`{
+		patch, err := ParseObject([]byte(`{
 			"@id": "https://example.com",
 			"http://www.w3.org/ns/activitystreams#content": "bye"
 		}`))

--- a/models/entity.go
+++ b/models/entity.go
@@ -52,7 +52,7 @@ func NewEntity(kind EntityKind, data []byte) (*Entity, error) {
 // Overwrites Object with Data. Called automatically by EntityStore.Get*() and NewEntity().
 func (e *Entity) SyncDataToObject() error {
 	if len(e.Data) > 0 {
-		obj, err := ld.NewObject(e.Data)
+		obj, err := ld.ParseObject(e.Data)
 		if err != nil {
 			return err
 		}

--- a/tools/nsgen/main.go
+++ b/tools/nsgen/main.go
@@ -101,7 +101,7 @@ func NamespaceFragments(ns *Namespace) ([]*ld.Object, error) {
 
 	// Turn it into JSON-LD fragments.
 	ldData, err := TurtleToJSONLD(ns.Long, turtleData)
-	fragments, err := ld.NewObjects(ldData)
+	fragments, err := ld.ParseObjects(ldData)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Renamed `NewObject` to the more fitting `ParseObject`.
- Added a new `NewObject(id string, typ ...string) *Object` function.
- Added setters for `@id`, `@type`, `@value`.
- Renamed `ToArray` and `ToStringArray` to `ToSlice` and `ToStringSlice`.
- Fixed both of the above to handle `[]string` properly alongside `[]interface{}`.
- Fixed a nil map assignment in `Object.Set()`.