### PR TITLE
Fixing empty string cases

### DIFF
--- a/ingress/rules/c2s.go
+++ b/ingress/rules/c2s.go
@@ -151,7 +151,8 @@ func C2SGenerateIDs(ctx context.Context, src ld.Source, actor, stream *models.En
 				}
 				objectID += slug
 			}
-		} else {
+		}
+		if objectID == "" {
 			objectID = lib.GenSnowflake().String()
 		}
 

--- a/ingress/rules/c2s_test.go
+++ b/ingress/rules/c2s_test.go
@@ -140,6 +140,30 @@ func TestC2SGenerateIDs(t *testing.T) {
 		assert.Equal(t, "https://example.com/~jsmith/im-gay", note.ID())
 	})
 
+	t.Run("Empty Name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		flakeGen := lib.NewMockSnowflakeGenerator(ctrl)
+		lib.DefaultSnowflakeGenerator = flakeGen
+
+		gomock.InOrder(
+			flakeGen.EXPECT().Generate().Return(snowflake.ID(1)).Times(1),
+			flakeGen.EXPECT().Generate().Return(snowflake.ID(2)).Times(1),
+		)
+
+		note := as.NewNote("")
+		note.SetName(ld.Value(""))
+		note.SetContent(ld.Value("Lorem ipsum dolor sit amet"))
+		create := as.NewCreate("")
+		create.SetObject(note)
+
+		activity := as.AsActivity(create)
+		assert.NoError(t, C2SGenerateIDs(ctx, ld.ClientToServer, actor, outbox, &activity))
+		assert.Equal(t, "https://example.com/~jsmith/outbox/1", create.ID())
+		assert.Equal(t, "https://example.com/~jsmith/2", note.ID())
+	})
+
 	t.Run("Long Name", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/ld/cast.go
+++ b/ld/cast.go
@@ -22,8 +22,8 @@ func ToString(raw interface{}) string {
 		}
 		return out
 	case map[string]interface{}:
-		if s := ToString(v["@value"]); s != "" {
-			return s
+		if val, ok := v["@value"]; ok {
+			return ToString(val)
 		}
 		return fmt.Sprint(v)
 	case fmt.Stringer:


### PR DESCRIPTION
`ld.ToString(ld.Value(""))` would return `"map[@value:]"` instead of `""`.
This would manifest, for instance, if somebody submitted a C2S Create for an entity with a blank string for a `name`.

Also, if you set a `name` containing nothing but punctuation, it'd end up with a blank ID, and blat the posting user's profile.