### PR TITLE
Run tests on Go 0.12 and 0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ language: go
 
 go:
 - "1.x"
-- "1.9.x"
-- "1.10.x"
+- "1.12.x"
+- "1.13.x"
 
 addons:
   postgresql: "9.6" # Use an up-to-date version of Postgres; default is 9.2.


### PR DESCRIPTION
Go 0.9 and 0.10 are ancient at this point.