### PR TITLE
Working serving of a couple of fixtures

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -24,10 +25,15 @@ var ingestCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var obj ld.Object
-		if err := json.Unmarshal(indata, &obj); err != nil {
+		var kv map[string]interface{}
+		if err := json.Unmarshal(indata, &kv); err != nil {
 			return err
 		}
+		kv, err = ld.Expand(context.Background(), kv, "")
+		if err != nil {
+			return err
+		}
+		obj := ld.Object{V: kv}
 		dump(obj)
 
 		// Entities ingested this way are always ObjectEntities.

--- a/fixtures/localhost-jane.json
+++ b/fixtures/localhost-jane.json
@@ -1,0 +1,13 @@
+{
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "@type": "Person",
+    "@id": "https://localhost/~jane",
+    "inbox": "https://localhost/~jane/-inbox",
+    "outbox": "https://localhost/~jane/-outbox",
+    "liked": "https://localhost/~jane/-liked",
+    "following": "https://localhost/~jane/-following",
+    "followers": "https://localhost/~jane/-followers",
+    "preferredUsername": "jane",
+    "name": "Jane Smith",
+    "summary": "meowpub test user"
+}

--- a/fixtures/localhost.json
+++ b/fixtures/localhost.json
@@ -1,0 +1,6 @@
+{
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "@type": "Service",
+    "@id": "https://localhost",
+    "name": "Test Domain"
+}

--- a/server/entities.go
+++ b/server/entities.go
@@ -34,7 +34,9 @@ func (n EntityNode) HandleRequest(req api.Request) api.Response {
 
 // Called by the Router to return a node at an arbitrary point in the tree.
 // This is called both by EntityNode.Traverse and the router.
-func Lookup(ctx context.Context, u *url.URL) (api.Traversible, error) {
+func Lookup(ctx context.Context, u_ *url.URL) (api.Traversible, error) {
+	u := *u_
+	u.Scheme = "https"
 	lib.GetLogger(ctx).Debug("looking up...", zap.String("url", u.String()))
 	e, err := models.GetStores(ctx).Entities().GetByID(u.String())
 	if err != nil {
@@ -45,5 +47,5 @@ func Lookup(ctx context.Context, u *url.URL) (api.Traversible, error) {
 		lib.GetLogger(ctx).Debug("Lookup found nothing", zap.String("url", u.String()))
 		return nil, nil
 	}
-	return EntityNode{e, u}, nil
+	return EntityNode{e, &u}, nil
 }

--- a/server/middleware/domains.go
+++ b/server/middleware/domains.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 
 	"github.com/meowpub/meow/lib"
@@ -11,7 +12,10 @@ import (
 func LocalDomains(domains []string) func(next api.Handler) api.Handler {
 	return func(next api.Handler) api.Handler {
 		return api.HandlerFunc(func(req api.Request) api.Response {
-			hostname := req.URL.Hostname()
+			hostname, _, _ := net.SplitHostPort(req.Host)
+			if hostname == "" {
+				hostname = req.Host
+			}
 			isLocal := false
 			for _, domain := range domains {
 				if hostname == domain {


### PR DESCRIPTION
"Fixture" is a Rails term for a bit of stock data that's loaded by its migration system, which isn't quite the right term for this, but here's some stock data to get a development server up and running.

Requests to `http://` URLs now always actually look up `https://` IDs, and they also handle requests where the hostname comes only from the `Host:` header properly.